### PR TITLE
changing the order of gauge commands

### DIFF
--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeTask.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeTask.java
@@ -87,11 +87,11 @@ public class GaugeTask extends DefaultTask {
     public ArrayList<String> createGaugeCommand() {
         ArrayList<String> command = new ArrayList<>();
         command.add(GAUGE);
-        addSpecsDir(command);
         addParallelFlags(command);
         addEnv(command);
         addTags(command);
         addAdditionalFlags(command);
+        addSpecsDir(command);
         return command;
     }
 


### PR DESCRIPTION
Hi @manupsunny, the issue (https://github.com/manupsunny/gauge-gradle-plugin/issues/1) I've raised earlier might be due to the order of gauge commands

For example when I run `gauge specs --env=chrome` i.e. `specs` before the `env`, then the specs are run with the default env. But If I run `gauge --env=chrome specs` i.e. `env` before the `specs`, then the `chrome` environment is run as expected. This could possibly be an issue with gauge itself. 

For now, lets try this and see if it fixes the issue of always running with default env.