### PR TITLE
Add gaugeRoot configuration option

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -48,6 +48,7 @@ gauge {
     env = 'dev'
     tags = 'tag1'
     additionalFlags = '--verbose'
+    gaugeRoot = '/opt/gauge'
 }
 
 ````
@@ -87,6 +88,7 @@ The following plugin properties can be additionally set:
 |nodes    | -Pnodes=3 | Number of parallel execution streams. Use with ```parallel```|
 |env      | -Penv=qa  | gauge env to run against  |
 |additionalFlags| -PadditionalFlags="--verbose" | Add additional gauge flags to execution|
+|gaugeRoot| -PgaugeRoot="/opt/gauge" | Path to gauge installation root|
 
 
 See gauge's [command line interface](http://getgauge.io/documentation/user/current/cli/index.html) for list of all flags that be used with **-PadditionalFlags** option.

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeExtension.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/GaugeExtension.java
@@ -28,6 +28,7 @@ public class GaugeExtension {
     private String tags;
     private String classpath;
     private String additionalFlags;
+    private String gaugeRoot;
 
     public String getSpecsDir() {
         return specsDir;
@@ -83,5 +84,13 @@ public class GaugeExtension {
 
     public void setAdditionalFlags(String additionalFlags) {
         this.additionalFlags = additionalFlags;
+    }
+
+    public String getGaugeRoot() {
+        return gaugeRoot;
+    }
+
+    public void setGaugeRoot(String gaugeRoot) {
+        this.gaugeRoot = gaugeRoot;
     }
 }

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
@@ -21,12 +21,12 @@ package com.thoughtworks.gauge.gradle.util;
 
 import com.thoughtworks.gauge.gradle.GaugeExtension;
 import com.thoughtworks.gauge.gradle.exception.GaugeExecutionFailedException;
+import org.apache.commons.lang.StringUtils;
 import org.gradle.api.Project;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -143,12 +143,13 @@ public class ProcessBuilderFactory {
     }
 
     private void addGaugeExecutable(ArrayList<String> command) {
+        String gauge;
         String gaugeRoot = extension.getGaugeRoot();
-        Path pathToGauge = Paths.get("");
-        if (gaugeRoot != null && !gaugeRoot.isEmpty()) {
-            pathToGauge = Paths.get(pathToGauge.toString(), gaugeRoot, "bin");
+        if (StringUtils.isNotEmpty(gaugeRoot)) {
+            gauge = Paths.get(gaugeRoot, "bin", GAUGE).toString();
+        } else {
+            gauge = GAUGE;
         }
-        pathToGauge = Paths.get(pathToGauge.toString(), GAUGE);
-        command.add(pathToGauge.toString());
+        command.add(gauge);
     }
 }

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
@@ -26,6 +26,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 
@@ -65,7 +67,7 @@ public class ProcessBuilderFactory {
 
     private ArrayList<String> createGaugeCommand() {
         ArrayList<String> command = new ArrayList<>();
-        command.add(GAUGE);
+        addGaugeExecutable(command);
         addTags(command);
         addParallelFlags(command);
         addEnv(command);
@@ -138,5 +140,15 @@ public class ProcessBuilderFactory {
             command.add(TAGS_FLAG);
             command.add(tags);
         }
+    }
+
+    private void addGaugeExecutable(ArrayList<String> command) {
+        String gaugeRoot = extension.getGaugeRoot();
+        Path pathToGauge = Paths.get("");
+        if (gaugeRoot != null && !gaugeRoot.isEmpty()) {
+            pathToGauge = Paths.get(pathToGauge.toString(), gaugeRoot, "bin");
+        }
+        pathToGauge = Paths.get(pathToGauge.toString(), GAUGE);
+        command.add(pathToGauge.toString());
     }
 }

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/PropertyManager.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/PropertyManager.java
@@ -36,6 +36,7 @@ public class PropertyManager {
     private static final String SPECS_DIR = "specsDir";
     private static final String IN_PARALLEL = "inParallel";
     private static final String ADDITIONAL_FLAGS = "additionalFlags";
+    private static final String GAUGE_ROOT = "gaugeRoot";
     private static final String RUNTIME = "runtime";
     private static final String CLASSES = "/classes";
 
@@ -57,6 +58,7 @@ public class PropertyManager {
         setAdditionalFlags();
         setClasspath();
         setSpecsDir();
+        setGaugeRoot();
     }
 
     private void setSpecsDir() {
@@ -112,6 +114,13 @@ public class PropertyManager {
             classpath += path + File.pathSeparator;
         }
         extension.setClasspath(classpath);
+    }
+
+    private void setGaugeRoot() {
+        String gaugeRoot = (String) properties.get(GAUGE_ROOT);
+        if (gaugeRoot != null) {
+            extension.setGaugeRoot(gaugeRoot);
+        }
     }
 
     private void addRuntimeClasspaths(HashSet<String> classPaths) {

--- a/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeExtensionTest.java
+++ b/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeExtensionTest.java
@@ -23,5 +23,6 @@ public class GaugeExtensionTest {
         assertNull(gauge.getTags());
         assertNull(gauge.getClasspath());
         assertNull(gauge.getAdditionalFlags());
+        assertNull(gauge.getGaugeRoot());
     }
 }

--- a/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeTaskTest.java
+++ b/plugin/src/test/java/com/thoughtworks/gauge/gradle/GaugeTaskTest.java
@@ -6,6 +6,7 @@ import org.gradle.testfixtures.ProjectBuilder;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -21,6 +22,7 @@ public class GaugeTaskTest {
     private static final String VERBOSE_FLAG = "--verbose";
     private static final String SPECS_FOLDER = "specsFolder";
     private static final String PARALLEL_FLAG = "--parallel";
+    private static final String GAUGE_ROOT = "/opt/gauge";
 
     private GaugeTask task;
     private Project project;
@@ -42,7 +44,7 @@ public class GaugeTaskTest {
         executeGaugeTask(process);
 
         List<String> command = factory.create().command();
-        assertTrue(command.contains(GAUGE));
+        assertTrue(command.contains(Paths.get(GAUGE_ROOT, "bin", GAUGE).toString()));
         assertTrue(command.contains(PARALLEL_FLAG));
         assertTrue(command.contains(NODES_FLAG));
         assertTrue(command.contains("2"));
@@ -62,12 +64,13 @@ public class GaugeTaskTest {
         gauge.setTags("tag1");
         gauge.setAdditionalFlags(VERBOSE_FLAG);
         gauge.setSpecsDir(SPECS_FOLDER);
+        gauge.setGaugeRoot(GAUGE_ROOT);
         task.executeGaugeSpecs(process);
     }
 
     private void setExpectations(Process process) throws InterruptedException {
         ArrayList<String> expectedCommand = new ArrayList<>();
-        expectedCommand.add(GAUGE);
+        expectedCommand.add(Paths.get(GAUGE_ROOT, "bin", GAUGE).toString());
         expectedCommand.add(PARALLEL_FLAG);
         expectedCommand.add(NODES_FLAG);
         expectedCommand.add("2");

--- a/scripts/pre_build.sh
+++ b/scripts/pre_build.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 echo deb https://dl.bintray.com/gauge/gauge-deb stable main | sudo tee -a /etc/apt/sources.list
 sudo apt-get update
 sudo apt-get install gauge

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,2 +1,3 @@
+#!/usr/bin/env bash
 cd plugin
 ../gradlew clean test


### PR DESCRIPTION
Installing gauge on macOS via Homebrew installs Gauge on `/usr/local/Cellar/gauge/` and the Gauge executable is symlinked to `/usr/local/bin/gauge` but trying to run the gauge task on IntelliJ fails because the environment variables are different for GUI apps. By adding this variable it is possible to configure a custom install path which allows running the tests on IDEs.