### PR TITLE
Use `run` subcommand for execution

### DIFF
--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
@@ -33,6 +33,7 @@ import java.util.Arrays;
 
 public class ProcessBuilderFactory {
     private static final String GAUGE = "gauge";
+    private static final String RUN_SUBCOMMAND = "run";
     private static final String ENV_FLAG = "--env";
     private static final String NODE_FLAG = "-n";
     private static final String TAGS_FLAG = "--tags";
@@ -68,6 +69,7 @@ public class ProcessBuilderFactory {
     private ArrayList<String> createGaugeCommand() {
         ArrayList<String> command = new ArrayList<>();
         addGaugeExecutable(command);
+        command.add(RUN_SUBCOMMAND);
         addTags(command);
         addParallelFlags(command);
         addEnv(command);


### PR DESCRIPTION
`gauge` command usage has been changed and the old usage will be deprecated in the next release. Following is the new usage.
```
gauge run specs/
```