### PR TITLE
update build classpath to support gradle 4+

### DIFF
--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/PropertyManager.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/PropertyManager.java
@@ -133,9 +133,16 @@ public class PropertyManager {
     }
 
     private void addBuildClasspaths(HashSet<String> classPaths) {
-        File classFolders = new File(project.getBuildDir().getAbsolutePath() + CLASSES);
-        for (File file : classFolders.listFiles()){
-            classPaths.add(file.getAbsolutePath());
+        findFiles(project.getBuildDir().getAbsolutePath() + CLASSES, classPaths);
+    }
+
+    private void findFiles(String dir, HashSet<String> classPaths) {
+      File files = new File(dir);
+      for (File file : files.listFiles()) {
+        if (file.isDirectory()) {
+          classPaths.add(file.getAbsolutePath());
+          findFiles(file.getAbsolutePath(), classPaths);
         }
+      }
     }
 }


### PR DESCRIPTION
This is my fix for issue #20 which I too was running into.  The directory structure under the build directory changed in gradle 4 to include another directory, java.  The change will recursively add directories under build/classes to the classpath.