### PR TITLE
Remove specsDir if --failed or --repeat flags are given

### DIFF
--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/ProcessBuilderFactory.java
@@ -111,9 +111,6 @@ public class ProcessBuilderFactory {
 
         if (specsDirectoryPath != null) {
             validateSpecsDirectory(specsDirectoryPath, command);
-        } else {
-            log.warn("Property 'specsDir' not set. Using default value => '%s'", "specs");
-            command.add(SPECS_FLAG);
         }
     }
 
@@ -122,13 +119,11 @@ public class ProcessBuilderFactory {
             for (String file : specsDirectoryPath.split(" ")) {
                 validateSingleSpecsDirectory(file, command);
             }
-        }
-        else if (specsDirectoryPath.contains(",")) {
+        } else if (specsDirectoryPath.contains(",")) {
             for (String file : specsDirectoryPath.split(",")) {
                 validateSingleSpecsDirectory(file, command);
             }
-        }
-        else {
+        } else {
             validateSingleSpecsDirectory(specsDirectoryPath, command);
         }
     }

--- a/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/PropertyManager.java
+++ b/plugin/src/main/java/com/thoughtworks/gauge/gradle/util/PropertyManager.java
@@ -39,6 +39,8 @@ public class PropertyManager {
     private static final String GAUGE_ROOT = "gaugeRoot";
     private static final String RUNTIME = "runtime";
     private static final String CLASSES = "/classes";
+    private final String FAILED = "--failed";
+    private final String REPEAT = "--repeat";
 
     private Project project;
     private GaugeExtension extension;
@@ -100,6 +102,9 @@ public class PropertyManager {
         String flags = (String) properties.get(ADDITIONAL_FLAGS);
         if (flags != null) {
             extension.setAdditionalFlags(flags);
+            if (flags.contains(FAILED) || flags.contains(REPEAT)) {
+                extension.setSpecsDir(null);
+            }
         }
     }
 


### PR DESCRIPTION
gauge provides a feature to re-run the failed specs by running `gauge run --failed`. This command fails if a specification dir is passed. 
Example: `gauge run --failed specs` will fail because `--failed` flag can't be used with specs dir subcommand.
This is same as `--repeat` flag as well.

The plugin should remove the specs dir if these flags are passed from the command line (using -PadditionFlags).
